### PR TITLE
Add sort index

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -7,6 +7,7 @@ class UserDashboard < Administrate::BaseDashboard
     updated_at: Field::DateTime,
     username: Field::String,
     role: EnumField,
+    sort_index: Field::Number,
     password: Field::Password,
     password_confirmation: Field::Password
   }.freeze
@@ -14,6 +15,7 @@ class UserDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     username
+    sort_index
     created_at
     updated_at
   ].freeze
@@ -22,14 +24,17 @@ class UserDashboard < Administrate::BaseDashboard
     id
     username
     role
+    sort_index
+    created_at
     updated_at
   ].freeze
 
   FORM_ATTRIBUTES = %i[
-    role
     username
     password
     password_confirmation
+    role
+    sort_index
   ].freeze
 
   COLLECTION_FILTERS = {}.freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,8 @@ class User < ApplicationRecord
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 
+  default_scope { order(sort_index: :asc) }
+
   def next_status
     next_enum(User.statuses, status)
   end

--- a/db/migrate/20201002103056_add_sort_index_to_users.rb
+++ b/db/migrate/20201002103056_add_sort_index_to_users.rb
@@ -1,0 +1,7 @@
+class AddSortIndexToUsers < ActiveRecord::Migration[6.0]
+  FIXNUM_MAX = (2**(4 * 8 - 2) - 1).freeze
+
+  def change
+    add_column :users, :sort_index, :integer, default: FIXNUM_MAX
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_162229) do
+ActiveRecord::Schema.define(version: 2020_10_02_103056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 2020_05_28_162229) do
     t.datetime "remember_me_token_expires_at"
     t.string "status", default: "unavailable", null: false
     t.string "duty_type"
+    t.integer "sort_index", default: 1073741823
     t.index ["remember_me_token"], name: "index_users_on_remember_me_token"
     t.index ["username"], name: "index_users_on_username", unique: true
   end

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -8,6 +8,7 @@ namespace :populate do
       User.create(
         username: username,
         role: "admin",
+        sort_index: 1,
         password: password,
         password_confirmation: password,
       )


### PR DESCRIPTION
Adds a new field to sort users on the presences dashboard. By default every user has a sort index equal to the MAX possible integer on ruby, so every new user appears last.