### PR TITLE
Use the locale to identify same user connections

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,10 +1,13 @@
 module ApplicationCable
+  # We are identifying connections with locale and current user
+  # Why locale? Because otherwise, the same user with different locale
+  # settings might have random language switches
   class Connection < ActionCable::Connection::Base
-    identified_by :current_user, :unique_hash
+    identified_by :current_user, :locale
 
     def connect
       self.current_user = find_verified_user
-      self.unique_hash = SecureRandom.hex(64)
+      self.locale = request.session["locale"]
     end
 
     private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,7 @@
 class ApplicationController < ActionController::Base
-  include HttpAcceptLanguage::AutoLocale
   include Pundit
 
-  before_action :require_login, :set_raven_context
+  before_action :require_login, :set_raven_context, :set_locale
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
 
   private
@@ -18,5 +17,10 @@ class ApplicationController < ActionController::Base
   def set_raven_context
     Raven.user_context(username: current_user.username) if current_user
     Raven.extra_context(params: params.to_unsafe_h, url: request.url)
+  end
+
+  def set_locale
+    I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
+    session[:locale] = I18n.locale
   end
 end


### PR DESCRIPTION
Before this we used a hack to make any ActionCable connection unique. This fix allow us to solve the language switch bug by using the `session.locale` to also identify connections.