### PR TITLE
Hide sentry variable and disable by default

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,4 +1,4 @@
 Raven.configure do |config|
-  config.dsn = "https://cb3f6cba3bf742cd8b1b6bbf88749053@o456594.ingest.sentry.io/5449816"
+  config.dsn = ENV["SENTRY_DSN"]
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end


### PR DESCRIPTION
Disable Sentry errors unless the environment variable is set.