### PR TITLE
Handle session problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.1
+          ruby-version: 2.7.2
 
       - name: Setup node
         uses: actions/setup-node@v2-beta

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ AllCops:
     - "bin/**/*"
     - "vendor/**/*"
     - "node_modules/**/*"
-  TargetRubyVersion: 2.7.1
+  TargetRubyVersion: 2.7.2
   NewCops: enable
 
 Layout/LineLength:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.1
-nodejs 12.18.4
+ruby 2.7.2
+nodejs 12.19.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.7.1"
+ruby "2.7.2"
 
 gem "activerecord-session_store"
 gem "administrate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,7 @@ DEPENDENCIES
   webpacker (~> 5.2.1)
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include Pundit
 
   before_action :require_login, :set_raven_context, :set_locale
+  after_action :refresh_session
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized
 
   private
@@ -22,5 +23,9 @@ class ApplicationController < ActionController::Base
   def set_locale
     I18n.locale = http_accept_language.compatible_language_from(I18n.available_locales)
     session[:locale] = I18n.locale
+  end
+
+  def refresh_session
+    ActiveRecord::SessionStore::Session.find_by(session_id: session.id).touch # rubocop:disable all
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,7 +13,7 @@ class SessionsController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    logged_in = login(user_params[:username], user_params[:password])
+    logged_in = login(user_params[:username], user_params[:password], true)
 
     if logged_in
       redirect_to(root_path, notice: "Login successful")

--- a/app/frontend/javascript/idleHandler.js
+++ b/app/frontend/javascript/idleHandler.js
@@ -1,0 +1,9 @@
+import { Idle } from "idlejs";
+
+// Refresh the page after 15 minutes of inactivity
+
+new Idle()
+  .whenNotInteractive()
+  .within(15)
+  .do(() => window.location.reload())
+  .start();

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -6,3 +6,4 @@ require("./application.css");
 require("../javascript/channels");
 require("../javascript/controllers");
 require("../javascript/datepicker");
+require("../javascript/idleHandler");

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,4 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  config.session_store :cache_store
-
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
@@ -14,21 +10,11 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
 
-  # Enable/disable caching. By default caching is disabled.
-  # Run rails dev:cache to toggle caching.
-  if Rails.root.join("tmp/caching-dev.txt").exist?
-    config.action_controller.perform_caching = true
-    config.action_controller.enable_fragment_cache_logging = true
-
-    config.cache_store = :redis_cache_store
-    config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
-    }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  config.action_controller.perform_caching = true
+  config.action_controller.enable_fragment_cache_logging = true
+  config.public_file_server.headers = {
+    "Cache-Control" => "public, max-age=#{2.days.to_i}"
+  }
 
   # Use delayed_job
   config.active_job.queue_adapter = :delayed_job

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,9 +53,6 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
-  # Use a different cache store in production.
-  config.cache_store = :redis_cache_store
-
   # Use delayed_job
   config.active_job.queue_adapter = :delayed_job
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,7 +23,6 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -3,6 +3,6 @@ Rails.application.config.cache_store = :redis_cache_store, {
   url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }
 }
 Rails.application.config.session_store :active_record_store,
-  serializer: :json,
-  key: "_firefighters_monitor_session",
-  same_site: :lax
+                                       serializer: :json,
+                                       key: "_firefighters_monitor_session",
+                                       same_site: :lax

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,8 @@
-Rails.application.config.session_store :active_record_store, key: "_firefighters_monitor_session", same_site: :lax
+Rails.application.config.cache_store = :redis_cache_store, {
+  driver: :hiredis,
+  url: ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" }
+}
+Rails.application.config.session_store :active_record_store,
+  serializer: :json,
+  key: "_firefighters_monitor_session",
+  same_site: :lax

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -4,7 +4,7 @@
 # Available submodules are: :user_activation, :http_basic_auth, :remember_me,
 # :reset_password, :session_timeout, :brute_force_protection, :activity_logging,
 # :magic_login, :external
-Rails.application.config.sorcery.submodules = []
+Rails.application.config.sorcery.submodules = [:remember_me]
 
 # Here you can configure each submodule's features.
 Rails.application.config.sorcery.configure do |config|
@@ -29,7 +29,7 @@ Rails.application.config.sorcery.configure do |config|
   # Allow the remember_me cookie to be set through AJAX
   # Default: `true`
   #
-  # config.remember_me_httponly =
+  config.remember_me_httponly = false
 
   # Set token randomness. (e.g. user activation tokens)
   # The length of the result string is about 4/3 of `token_randomness`.
@@ -285,7 +285,7 @@ Rails.application.config.sorcery.configure do |config|
     # logins/logouts (to support remembering on multiple browsers simultaneously).
     # Default: false
     #
-    # user.remember_me_token_persist_globally =
+    user.remember_me_token_persist_globally = true
 
     # -- user_activation --
     # The attribute name to hold activation state (active/pending).

--- a/lib/tasks/sessions.rake
+++ b/lib/tasks/sessions.rake
@@ -1,0 +1,6 @@
+namespace :sessions do
+  desc "Clears old sessions"
+  task clean: :environment do
+    ActiveRecord::SessionStore::Session.where("updated_at < ?", 1.day.ago).delete_all
+  end
+end

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@sentry/tracing": "^5.24.2",
     "cable_ready": "^4.4.0-pre0",
     "flatpickr": "^4.6.6",
+    "idlejs": "^3.0.0",
     "postcss-custom-properties": "^10.0.0",
     "postcss-easy-import": "^3.0.0",
     "postcss-nested": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4520,6 +4520,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
+idlejs@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/idlejs/-/idlejs-3.0.0.tgz#1861632ed2c426b4b929a98b652dade599fd9c58"
+  integrity sha512-rOF0xmgXBiSaC2tT+jedqkShlam6vAWWXAkLGkw2iNoO6ipcJ0qFV/vV4imjBkwEzW50Kwtc74LNQEWVAMU8wA==
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"


### PR DESCRIPTION
In order to keep sessions at a minimum, since Heroku has a 10,000 row limit on the free plan, I've made a few changes:
- Enable cookie storage for logins, so even if a session is deleted, the user is still logged in
- Add a rake task to delete sessions older than 1 day
- Adds an after_action callback to refresh existing active sessions
- Have the frontend refresh itself every 15 mins of idle time
- Minor version ruby update